### PR TITLE
Validate all values before throwing the exception for failure

### DIFF
--- a/src/config/variables.ts
+++ b/src/config/variables.ts
@@ -97,6 +97,14 @@ export function number(value: string): number {
   throw new ParseVariableError(`Non-number value found: ${value}`)
 }
 
+export function url(value: string): URL {
+  try {
+    return new URL(value)
+  } catch (e) {
+    throw new ParseVariableError(`Value is not a valid URL: ${value}`)
+  }
+}
+
 export function parseVariables<T extends Record<string, ConfigDeclaration<any>>>(definition: T): ParseFunction<T> {
   return (environment, file, context) => {
     const isProd = context === 'production'

--- a/test/config/variables.test.ts
+++ b/test/config/variables.test.ts
@@ -7,6 +7,7 @@ import {
   string,
   boolean,
   number,
+  url,
   defined,
   parseVariables,
   ConfigDeclaration,
@@ -16,14 +17,47 @@ import dotenv from 'dotenv-extended'
 
 describe('parseVariables', () => {
   describe('boolean', () => {
+    it('cast type to boolean', () => {
+      expect(boolean('true')).toEqual(true)
+      expect(boolean('false')).toEqual(false)
+    })
+
+    it('should throw exception for js-weird booleans', () => {
+      expect(() => boolean('1')).toThrowError(/Non-boolean value found/)
+      expect(() => boolean('0')).toThrowError(/Non-boolean value found/)
+      expect(() => boolean('')).toThrowError(/Non-boolean value found/)
+    })
+
     it('should throw exception if casting wrong type to boolean', () => {
       expect(() => boolean('1234')).toThrowError(/Non-boolean value found/)
     })
   })
 
   describe('number', () => {
+    it('should cast value to number', () => {
+      expect(number('123')).toEqual(123)
+    })
+
     it('should throw exception if casting wrong type to number', () => {
       expect(() => number('a string value')).toThrowError(/Non-number value found/)
+    })
+
+    it('should not accept positive infinite as a number', () => {
+      expect(() => number(`${Number.POSITIVE_INFINITY}`)).toThrowError(/Non-number value found/)
+    })
+
+    it('should not accept negative infinite as a number', () => {
+      expect(() => number(`${Number.NEGATIVE_INFINITY}`)).toThrowError(/Non-number value found/)
+    })
+  })
+
+  describe('url', () => {
+    it('should return the qualified URL', () => {
+      expect(url('https://aito.ai')).toEqual(new URL('https://aito.ai'))
+    })
+
+    it('should throw exception if not a fully qualified URL', () => {
+      expect(() => url('a string value')).toThrowError(/Value is not a valid URL/)
     })
   })
 

--- a/test/config/variables.test.ts
+++ b/test/config/variables.test.ts
@@ -1,7 +1,18 @@
 /**
  * Licensed under the Apache License, Version 2.0.
  */
-import { boolean, number, defined } from '../../src/config/variables'
+import {
+  optional,
+  required,
+  string,
+  boolean,
+  number,
+  defined,
+  parseVariables,
+  ConfigDeclaration,
+  CombinedParseVariableError,
+} from '../../src/config/variables'
+import dotenv from 'dotenv-extended'
 
 describe('parseVariables', () => {
   describe('boolean', () => {
@@ -19,6 +30,55 @@ describe('parseVariables', () => {
   describe('required', () => {
     it('should throw exception if casting wrong type to number', () => {
       expect(() => defined(number)(undefined)).toThrowError(/environment variable is not set properly/)
+    })
+  })
+
+  describe('multiple validations', () => {
+    const declaration = {
+      A_STRING_VALUE: required(string),
+      A_BOOLEAN_VALUE: optional(boolean),
+      A_NUMBER_VALUE: optional(number),
+      PORT: optional(number),
+    }
+
+    const emptyConfig: dotenv.IEnvironmentMap = {}
+    const invalidConfig: dotenv.IEnvironmentMap = {
+      A_STRING_VALUE: undefined as any as string,
+      A_BOOLEAN_VALUE: 'Not a boolean',
+      A_NUMBER_VALUE: `${Number.POSITIVE_INFINITY}`,
+      PORT: 'Hex, maybe?',
+    }
+
+    function call() {
+      parseVariables(declaration)(invalidConfig, emptyConfig, 'production')
+    }
+
+    it('should throw exception when errors', () => {
+      expect(call).toThrowError()
+    })
+
+    it('should list the number of errors in the exception', () => {
+      try {
+        call()
+      } catch (err) {
+        if (err instanceof CombinedParseVariableError) {
+          expect(err.message).toContain('There were 4 errors while parsing')
+        } else {
+          throw err
+        }
+      }
+    })
+
+    it('should contain an array of all causing errors in the top-level exception', () => {
+      try {
+        call()
+      } catch (err) {
+        if (err instanceof CombinedParseVariableError) {
+          expect(err.cause).toHaveLength(4)
+        } else {
+          throw err
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
Validate all configured values in the config before throwing the exception. 
This should ease fixing the problem, as you can get an error message for each problem in a single error message. 
